### PR TITLE
Use BridgeTalk to send message to adobe-broadcast from Illustrator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,12 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    },
+    "typescript": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
+      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-node",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "homepage": "https://github.com/rkamysz/adobe-node#readme",
   "devDependencies": {
-    "@types/node": "^12.12.5"
+    "@types/node": "^12.12.5",
+    "typescript": "^3.8.2"
   },
   "dependencies": {
     "@types/minimist": "^1.2.0",

--- a/src/broadcast.ts
+++ b/src/broadcast.ts
@@ -20,10 +20,9 @@ const broadcastMethods: Map<AdobeAppName, (cmd: string, payload: string) => stri
   bt.body += 'app.system(sys);';
   bt.onError = function(bt)  
   {  
-    alert(bt.body); 
+    alert("Error from BridgeTalk: " + bt.body); 
   };
   bt.send();
-  alert(bt.body);
   `]
 ]);
 

--- a/src/broadcast.ts
+++ b/src/broadcast.ts
@@ -5,11 +5,17 @@ const broadcastMethods: Map<AdobeAppName, (cmd: string, payload: string) => stri
   [AdobeAppName.Animate, (cmd: string, payload: string) => `FLfile.runCommandLine("${cmd}");`],
   [AdobeAppName.Photoshop, (cmd: string, payload: string) => `app.system("${cmd}");`],
   [AdobeAppName.Illustrator, (cmd: string, command: string) => `
+  if (!__stdout) {
+    __stdout = "{}";
+  }
+  if (!__stderr) {
+    __stderr = "";
+  }
   const bt = new BridgeTalk();
   bt.target = 'bridge';
   const btCmd = '${cmd.replace(/'/g, "\\'")}';
   bt.body = 'const cmd = "' + btCmd + '";';
-  bt.body += 'const msg = \\\'{"command": "${command}", "stdout": "' + __stdout + '", "stderr": "' + __stderr + '"}\\\';';
+  bt.body += 'const msg = \\\'{"command": "${command}", "stdout": ' + __stdout + ', "stderr": "' + __stderr + '"}\\\';';
   bt.body += 'const sys = cmd + " --msg=\\\'" + msg + "\\\'";';
   bt.body += 'app.system(sys);';
   bt.onError = function(bt)  

--- a/src/broadcast.ts
+++ b/src/broadcast.ts
@@ -4,12 +4,12 @@ import { exec } from 'child_process';
 const broadcastMethods: Map<AdobeAppName, (cmd: string, payload: string) => string> = new Map<AdobeAppName, (cmd: string, payload: string) => string>([
   [AdobeAppName.Animate, (cmd: string, payload: string) => `FLfile.runCommandLine("${cmd}");`],
   [AdobeAppName.Photoshop, (cmd: string, payload: string) => `app.system("${cmd}");`],
-  [AdobeAppName.Illustrator, (cmd: string, payload: string) => `
+  [AdobeAppName.Illustrator, (cmd: string, command: string) => `
   const bt = new BridgeTalk();
   bt.target = 'bridge';
   const btCmd = '${cmd.replace(/'/g, "\\'")}';
   bt.body = 'const cmd = "' + btCmd + '";';
-  bt.body += 'const msg = \\\'${payload}\\\';';
+  bt.body += 'const msg = \\\'{"command": "${command}", "stdout": "' + __stdout + '", "stderr": "' + __stderr + '"}\\\';';
   bt.body += 'const sys = cmd + " --msg=\\\'" + msg + "\\\'";';
   bt.body += 'app.system(sys);';
   bt.onError = function(bt)  
@@ -21,22 +21,21 @@ const broadcastMethods: Map<AdobeAppName, (cmd: string, payload: string) => stri
   `]
 ]);
 
-const buildBroadcastCommand = (host: string, port: number, message: string) =>
+const buildBroadcastCommand = (host: string, port: number) =>
   `adobe-broadcast --host='${host}' --port=${port}`;
 
 export const newBroadcastBuilder = (config: Config): BroadcastBuilder => {
 
   return {
     build(command: string) {
-      const payload: string = `{"command": "${command}"}`;
       const broadcast: (msg: string, payload: string) => string = broadcastMethods.get(config.app.name);
-      const cmd: string = buildBroadcastCommand(config.host, config.port, payload);
-      return broadcast(cmd, payload);
+      const cmd: string = buildBroadcastCommand(config.host, config.port);
+      return broadcast(cmd, command);
     }
   }
 }
 
 export const broadcast = (host: string, port: number, message: BroadcastMessage) => {
-  const cmd: string = buildBroadcastCommand(host, port, JSON.stringify(message));
+  const cmd: string = buildBroadcastCommand(host, port);
   exec(cmd);
 }

--- a/src/broadcast.ts
+++ b/src/broadcast.ts
@@ -1,23 +1,37 @@
 import { AdobeAppName, BroadcastBuilder, BroadcastMessage, Config } from "./api";
 import { exec } from 'child_process';
 
-const broadcastMethods: Map<AdobeAppName, (cmd: string) => string> = new Map<AdobeAppName, (cmd: string) => string>([
-  [AdobeAppName.Animate, (cmd: string) => `FLfile.runCommandLine("${cmd}");`],
-  [AdobeAppName.Photoshop, (cmd: string) => `app.system("${cmd}");`],
-  [AdobeAppName.Illustrator, (cmd: string) => `app.system("${cmd}");`],
+const broadcastMethods: Map<AdobeAppName, (cmd: string, payload: string) => string> = new Map<AdobeAppName, (cmd: string, payload: string) => string>([
+  [AdobeAppName.Animate, (cmd: string, payload: string) => `FLfile.runCommandLine("${cmd}");`],
+  [AdobeAppName.Photoshop, (cmd: string, payload: string) => `app.system("${cmd}");`],
+  [AdobeAppName.Illustrator, (cmd: string, payload: string) => `
+  const bt = new BridgeTalk();
+  bt.target = 'bridge';
+  const btCmd = '${cmd.replace(/'/g, "\\'")}';
+  bt.body = 'const cmd = "' + btCmd + '";';
+  bt.body += 'const msg = \\\'${payload}\\\';';
+  bt.body += 'const sys = cmd + " --msg=\\\'" + msg + "\\\'";';
+  bt.body += 'app.system(sys);';
+  bt.onError = function(bt)  
+  {  
+    alert(bt.body); 
+  };
+  bt.send();
+  alert(bt.body);
+  `]
 ]);
 
 const buildBroadcastCommand = (host: string, port: number, message: string) =>
-  `adobe-broadcast --host='${host}' --port=${port} --msg='${message}'`;
+  `adobe-broadcast --host='${host}' --port=${port}`;
 
 export const newBroadcastBuilder = (config: Config): BroadcastBuilder => {
 
   return {
     build(command: string) {
-      const payload: string = `{\\"command\\":\\"${command}\\",\\"stdout\\":\\"" + __stdout + "\\", \\"stderr\\":\\"" + __stderr + "\\" }`;
-      const broadcast: (msg: string) => string = broadcastMethods.get(config.app.name);
+      const payload: string = `{"command": "${command}"}`;
+      const broadcast: (msg: string, payload: string) => string = broadcastMethods.get(config.app.name);
       const cmd: string = buildBroadcastCommand(config.host, config.port, payload);
-      return broadcast(cmd);
+      return broadcast(cmd, payload);
     }
   }
 }

--- a/src/broadcast.ts
+++ b/src/broadcast.ts
@@ -1,10 +1,20 @@
 import { AdobeAppName, BroadcastBuilder, BroadcastMessage, Config } from "./api";
 import { exec } from 'child_process';
 
-const broadcastMethods: Map<AdobeAppName, (cmd: string, payload: string) => string> = new Map<AdobeAppName, (cmd: string, payload: string) => string>([
-  [AdobeAppName.Animate, (cmd: string, payload: string) => `FLfile.runCommandLine("${cmd}");`],
-  [AdobeAppName.Photoshop, (cmd: string, payload: string) => `app.system("${cmd}");`],
-  [AdobeAppName.Illustrator, (cmd: string, command: string) => `
+const createPayload = (command: string): string => {
+  return `{\\"command\\":\\"${command}\\",\\"stdout\\":\\"" + __stdout + "\\", \\"stderr\\":\\"" + __stderr + "\\" }`;
+};
+
+const buildBroadcastCommand = (host: string, port: number, message: string): string => {
+  return `adobe-broadcast --host='${host}' --port=${port} --msg='${message}'`;
+}
+
+const broadcastMethods: Map<AdobeAppName, (host: string, port: number, command: string) => string> = new Map<AdobeAppName, (host: string, port: number, command: string) => string>([
+  [AdobeAppName.Animate, (host: string, port: number, command: string) => `FLfile.runCommandLine("${buildBroadcastCommand(host, port, createPayload(command))}");`],
+  [AdobeAppName.Photoshop, (host: string, port: number, command: string) => `app.system("${buildBroadcastCommand(host, port, createPayload(command))}");`],
+  [AdobeAppName.Illustrator, (host: string, port: number, command: string) => {
+    const cmd = `adobe-broadcast --host='${host}' --port=${port}`;
+    return `
   if (!__stdout) {
     __stdout = "{}";
   }
@@ -23,24 +33,22 @@ const broadcastMethods: Map<AdobeAppName, (cmd: string, payload: string) => stri
     alert("Error from BridgeTalk: " + bt.body); 
   };
   bt.send();
-  `]
+  `
+  }
+  ]
 ]);
-
-const buildBroadcastCommand = (host: string, port: number) =>
-  `adobe-broadcast --host='${host}' --port=${port}`;
 
 export const newBroadcastBuilder = (config: Config): BroadcastBuilder => {
 
   return {
     build(command: string) {
-      const broadcast: (msg: string, payload: string) => string = broadcastMethods.get(config.app.name);
-      const cmd: string = buildBroadcastCommand(config.host, config.port);
-      return broadcast(cmd, command);
+      const broadcast = broadcastMethods.get(config.app.name);
+      return broadcast(config.host, config.port, command);
     }
   }
 }
 
 export const broadcast = (host: string, port: number, message: BroadcastMessage) => {
-  const cmd: string = buildBroadcastCommand(host, port);
+  const cmd: string = buildBroadcastCommand(host, port, JSON.stringify(message));
   exec(cmd);
 }

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -2,26 +2,29 @@ import { AdobeEventListener, BroadcastMessage } from './api';
 import { Socket, Server, createServer } from 'net';
 
 const newAdobeAppListener = (host: string, port: number, callback: (commandName: string) => void): AdobeEventListener => {
-  
+
   const callbacks: Map<string, Function> = new Map<string, Function>();
   let server: Server;
-  let client:Socket;
+  let client: Socket;
 
   function connectionListener(socket: Socket) {
     client = socket;
     socket.on('data', (buffer: Buffer) => {
-      const data: BroadcastMessage = JSON.parse(buffer.toString());
-      
-      if (callbacks.has(data.command)) {
-        callbacks.get(data.command)(data.stdout, data.stderr);
+      try {
+        const dataString = buffer.toString();
+        const data: any = JSON.parse(dataString);
+        if (callbacks.has(data.command)) {
+          callbacks.get(data.command)(data.stdout, data.stderr);
+        }
+        callback(data.command);
+      } catch (error) {
+        console.error("Failed to convert data: " + error);
       }
-
-      callback(data.command);
     });
   }
 
   function disposeServer() {
-    if(client) {
+    if (client) {
       client.end();
     }
     server = null;

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -14,7 +14,8 @@ const newAdobeAppListener = (host: string, port: number, callback: (commandName:
         const dataString = buffer.toString();
         const data: any = JSON.parse(dataString);
         if (callbacks.has(data.command)) {
-          callbacks.get(data.command)(data.stdout, data.stderr);
+          const callback = callbacks.get(data.command);
+          callback(data.stdout, data.stderr);
         }
         callback(data.command);
       } catch (error) {

--- a/src/script-builder.ts
+++ b/src/script-builder.ts
@@ -10,9 +10,8 @@ var ___{{__command__}} = (function() {
       __stdout = {{__fn__}}
     } catch (e) {
       __stderr = e;
-    } finally {
-      {{__broadcast__}}
-    }
+    } 
+    {{__broadcast__}}
   })();`;
 
 const newAdobeScriptBuilder = (): AdobeScriptBuilder => {


### PR DESCRIPTION
Adobe Illustrator doesn't support app.system() calls. So I had to search for another way to invoke the adobe-broadcast script from Illustrator.

I was able to use BridgeTalk for the callbacks. I hope we'll find a simpler way in the future, but at least it works :)

@rkamysz: My branch contains some general changes as well (Adding typescript package locally, so no global npm install is necessary for development; Move broadcast command outside finally block so an error is reported if something goes wrong with the broadcast; Throw an error if data from adobe-broadcast couldn't be parsed). Feel free to  ignore/revert those changes before merging the branch.